### PR TITLE
Improve disconnected condition to avoid waiting too long when unplug …

### DIFF
--- a/SCRIPTS/RF2_touch/widgets/rf2_server.lua
+++ b/SCRIPTS/RF2_touch/widgets/rf2_server.lua
@@ -403,7 +403,7 @@ end
 local function background(wgt)
     rf2fc.msp.ctl.lastServerTime = rf2.clock()
 
-    if (rf2.clock() - rf2fc.msp.ctl.lastUpdateTime) > 10 then
+    if (rf2.clock() - rf2fc.msp.ctl.lastUpdateTime) > 10 or getValue("RQly") <= 0 then
         rf2fc.msp.ctl.connected = false
     end
 


### PR DESCRIPTION
When unplug the battery, it is waiting too long for disconnected event. So i added 1 more condition is RQly <= 0 to trigger the event